### PR TITLE
repository_nameでgitのremote original urlがhttpsの場合にエラーが出ていた問題を修正した

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,14 @@ PATH
   remote: .
   specs:
     pr-daikou (0.3.1)
+      git_clone_url
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    git_clone_url (2.0.0)
+      uri-ssh_git (>= 2.0)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
@@ -22,6 +25,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     unicode-display_width (1.3.3)
+    uri-ssh_git (2.0.0)
 
 PLATFORMS
   ruby

--- a/lib/pr-daikou/host/github.rb
+++ b/lib/pr-daikou/host/github.rb
@@ -1,6 +1,6 @@
 require 'json'
 require 'shellwords'
-require 'uri'
+require 'git_clone_url'
 
 module PRDaikou
   module Host
@@ -40,12 +40,19 @@ module PRDaikou
 
       # ==== Examples
       #
+      #   repository_name('git@github.com:rvillage/pr-daikou.git')       # rvillage/pr-daikou
       #   repository_name('ssh://git@github.com/rvillage/pr-daikou.git') # rvillage/pr-daikou
       #   repository_name('https://github.com/rvillage/pr-daikou')       # rvillage/pr-daikou
+      #   repository_name('git://github.com/rvillage/pr-daikou.git')     # rvillage/pr-daikou
       #
       def repository_name(url = `git config --get remote.origin.url`.strip)
-        path = URI.parse(url).path
-        path[1...path.rindex('.')]
+        path = GitCloneUrl.parse(url).path
+
+        if path.start_with? '/'
+          path.slice!(0)
+        end
+
+        path[0...path.split('.').first.size]
       end
     end
   end

--- a/lib/pr-daikou/host/github.rb
+++ b/lib/pr-daikou/host/github.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'shellwords'
+require 'uri'
 
 module PRDaikou
   module Host
@@ -37,8 +38,14 @@ module PRDaikou
         "https://#{ENV['GITHUB_ACCESS_TOKEN']}@github.com/#{repository_name}"
       end
 
-      def repository_name
-        /^.+?github.com[:\/](?<repository_name>.+?)\.git$/.match(`git config --get remote.origin.url`)[:repository_name]
+      # ==== Examples
+      #
+      #   repository_name('ssh://git@github.com/rvillage/pr-daikou.git') # rvillage/pr-daikou
+      #   repository_name('https://github.com/rvillage/pr-daikou')       # rvillage/pr-daikou
+      #
+      def repository_name(url = `git config --get remote.origin.url`.strip)
+        path = URI.parse(url).path
+        path[1...path.rindex('.')]
       end
     end
   end

--- a/pr-daikou.gemspec
+++ b/pr-daikou.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
+  spec.add_runtime_dependency 'git_clone_url'
   spec.add_development_dependency 'bundler', '~> 1.16'
 end


### PR DESCRIPTION
`git config --get remote.origin.url`の結果がsshではなくhttpsの場合に下記のエラーが出ていました。


```
/opt/hostedtoolcache/Ruby/2.6.3/x64/lib/ruby/gems/2.6.0/gems/pr-daikou-0.3.1/lib/pr-daikou/host/github.rb:41:in `repository_name': undefined method `[]' for nil:NilClass (NoMethodError)
  from /opt/hostedtoolcache/Ruby/2.6.3/x64/lib/ruby/gems/2.6.0/gems/pr-daikou-0.3.1/lib/pr-daikou/host/github.rb:37:in `repository_url'
  from /opt/hostedtoolcache/Ruby/2.6.3/x64/lib/ruby/gems/2.6.0/gems/pr-daikou-0.3.1/lib/pr-daikou/host/github.rb:14:in `create_branch'
  from /opt/hostedtoolcache/Ruby/2.6.3/x64/lib/ruby/gems/2.6.0/gems/pr-daikou-0.3.1/lib/pr-daikou.rb:18:in `exec'
  from /opt/hostedtoolcache/Ruby/2.6.3/x64/lib/ruby/gems/2.6.0/gems/pr-daikou-0.3.1/bin/pr-daikou:5:in `<top (required)>'
  from /opt/hostedtoolcache/Ruby/2.6.3/x64/bin/pr-daikou:23:in `load'
  from /opt/hostedtoolcache/Ruby/2.6.3/x64/bin/pr-daikou:23:in `<main>'
##[error]Process completed with exit code 1.
```